### PR TITLE
docs: Rewrite README into full project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,100 @@
-# KurunthogaiSongOfTheDay
-Twitter bot to tweet one Kurunthogai song every day. 
+# Kurunthogai Song of the Day
 
-Credits :
+A Twitter/X bot that posts one poem from *Kurunthogai* — a classical Tamil
+anthology of 401 Sangam-era love poems — every day.
 
-Project - https://github.com/KaniyamFoundation/DailyOneTamilWord
+## Features
 
-Author - Khaleel - https://github.com/khaleeljageer
+- Publishes one poem daily, with its index, verses, poet's name and *thinai*
+  (landscape) type, plus the `#தினமொரு_குறுந்தொகை` hashtag.
+- Scrapes and normalises all 401 poems from
+  [Tamil Virtual University](http://www.tamilvu.org) and
+  [Tamil Wikisource](https://ta.wikisource.org).
+- Tracks progress in a hosted database so no poem repeats until the cycle ends.
+- Runs unattended on a configurable daily schedule.
+
+## How it works
+
+1. **Scrape** — `kurunthogai_tamilvu_poems_scrapper.py` parses each source page
+   into `Kurunthogai` objects (`kurunthogai_popo.py`).
+2. **Store** — `tamilvu_back4app.py` writes every poem to a Back4App (Parse)
+   class with an `is_tweeted` flag.
+3. **Select** — the bot queries the first poem where `is_tweeted = false` and
+   formats it for posting.
+4. **Post** — `kurunthogai_tweeter.py` publishes it via the Twitter API and the
+   record is marked as tweeted.
+5. **Schedule** — `clock.py` uses APScheduler to trigger the job at the
+   configured day/hour/minute.
+
+## Tech stack
+
+Python 3.6 · requests · BeautifulSoup 4 · python-twitter · APScheduler ·
+python-dotenv · Back4App (Parse) · Heroku
+
+## Setup
+
+```bash
+git clone https://github.com/velram/KurunthogaiSongOfTheDay.git
+cd KurunthogaiSongOfTheDay
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Create a `local.env` file (loaded by `local_config.py`; never commit it):
+
+```env
+enable_twitter_posting=True
+invoke_db_loader=False
+
+twitter_api_key=...
+twitter_api_secret_key=...
+twitter_access_token_key=...
+twitter_access_token_secret=...
+
+back_4_app_parse_application_id=...
+back_4_app_api_key=...
+back4app_kurunthogai_db_url=https://parseapi.back4app.com/classes/KurunthogaiPoems
+
+twitter_hashtag=#தினமொரு_குறுந்தொகை
+tweet_schedule_day=*
+tweet_schedule_hour=8
+tweet_schedule_minute=0
+```
+
+## Usage
+
+```bash
+# Post today's poem once
+python todays_kurunthogai_tamilvu.py
+
+# Run the scheduler (long-running)
+python clock.py
+
+# One-time: scrape sources and load the database
+python kurunthogai_tamilvu_poems_scrapper.py   # set invoke_db_loader=True
+```
+
+## Deployment
+
+Deploys to Heroku as a `clock` process (see `Procfile` and `runtime.txt`).
+Set every key from `local.env` as a Heroku config var.
+
+## Data
+
+The full dataset is published as JSON in
+[kurunthogai-api](https://github.com/velram/kurunthogai-api)
+(`KurunthogaiPoems.json`, also included here).
+
+## License
+
+Released under the [GNU GPL v3.0](LICENSE).
+
+## Credits
+
+Inspired by
+[DailyOneTamilWord](https://github.com/KaniyamFoundation/DailyOneTamilWord)
+by [Khaleel Jageer](https://github.com/khaleeljageer) and the Kaniyam
+Foundation. Poem texts courtesy of Tamil Virtual University and Tamil
+Wikisource.


### PR DESCRIPTION
# docs: Rewrite README into full project documentation

**Branch:** `doc/readme-update` → `master`
**Type:** Documentation only — no code, dependency, or behaviour changes.

## Summary

The previous `README.md` was a three-line stub (one-sentence description plus a
credits block). This MR replaces it with a structured, industry-standard README
so that a new contributor or operator can understand, run, and deploy the bot
without reading the source.

## What changed

| File | Change |
|------|--------|
| `README.md` | Rewritten: +97 / −5 lines |

Single commit: `f99ac88`.

## New README structure

| Section | Contents |
|---------|----------|
| **Overview** | One-paragraph description of the bot and of *Kurunthogai* (401 Sangam-era Tamil poems). |
| **Features** | Daily single-poem posting, dataset scope, non-repeating cycle via DB flag, unattended scheduling. |
| **How it works** | The scrape → store → select → post → schedule pipeline, each step linked to its module (`kurunthogai_tamilvu_poems_scrapper.py`, `tamilvu_back4app.py`, `kurunthogai_tweeter.py`, `clock.py`). |
| **Tech stack** | Python 3.6, requests, BeautifulSoup 4, python-twitter, APScheduler, python-dotenv, Back4App (Parse), Heroku. |
| **Setup** | Clone, virtualenv, `pip install -r requirements.txt`. |
| **Configuration** | Annotated `local.env` template listing every key read by `local_config.py` (Twitter API, Back4App, hashtag, schedule). |
| **Usage** | Commands for a one-off post, the long-running scheduler, and the one-time DB load. |
| **Deployment** | Heroku `clock` process (`Procfile`, `runtime.txt`); config vars. |
| **Data** | Link to the companion `kurunthogai-api` JSON dataset. |
| **License** | GNU GPL v3.0 (matches the existing `LICENSE` file). |
| **Credits** | Retains original attribution to DailyOneTamilWord / Khaleel Jageer / Kaniyam Foundation; adds source-text attribution. |

## Notes for the reviewer

- All module names, env-var keys, and commands were cross-checked against the
  current source (`local_config.py`, `Procfile`, `requirements.txt`,
  `todays_kurunthogai_tamilvu.py`).
- The `local.env` schedule and hashtag values are **illustrative examples**, not
  the production configuration.
- Kept under 500 words of prose by request.
- No secrets are included; `local.env` remains git-ignored.

## Checklist

- [x] Content verified against source
- [x] Markdown renders correctly on the Git host
- [x] Links resolve
- [x] No code or dependency changes
